### PR TITLE
Add new components for JavaScript Engine

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -137,9 +137,12 @@ addComponentMapping('mobile', 'Firefox for Android');
 addComponentMapping('mobile', 'Core', ['Widget: Android', 'mozglue']);
 addComponentMapping('jseng', 'Core',
                     ['Javascript Engine',
+                     'JavaScript Engine: JIT',
+                     'JavaScript: GC',
+                     'JavaScript: Internationalization API',
+                     'JavaScript: Standard Library',
                      'js-ctypes',
-                     'XPConnect',
-                     'Nanojit']);
+                     'XPConnect']);
 addComponentMapping('media', 'Core', ['Video/Audio', 'WebRTC', 'WebRTC: Audio/Video',
                                       'WebRTC: Signalling']);
 addComponentMapping('ff', 'Firefox');


### PR DESCRIPTION
Also remove "Nanojit" because it's an ancient component for Adobe's retired Tamarin VM.
