### PR TITLE
Issue 86 - set include_fields on bz queries

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -506,6 +506,7 @@ function retrieveResults(category) {
                         bug_mentor_type: 'contains',
                         whiteboard_type: 'contains_all',
                         bug_status: ["NEW","ASSIGNED","REOPENED", "UNCONFIRMED"],
+                        include_fields: ["id","assigned_to","summary","last_change_time"],
                         /*component_type: 'equals',*/
                         product: ''};
     for (var param in mapping[i]) {


### PR DESCRIPTION
bugsahoy should use include_fields to limit search results.
this significantly speeds up bugzilla queries; eg. 5.5s without include_fields, 2s with.
