### PR TITLE
Search java] to prevent java queries searching javascript bugs

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -300,7 +300,7 @@ addSimpleMapping('langs', 'sh', 'Core', 'Build Config');
 addSimpleMapping('langs', 'sh', 'MailNews Core', 'Build Config');
 addSimpleMapping('langs', 'java', 'Core', 'Widget: Android');
 addSimpleMapping('langs', 'java', 'Mozilla Services', 'Android Sync');
-addLanguageMapping('java', 'java');
+addLanguageMapping('java', 'java]');
 addLanguageMapping('js', 'js');
 addSimpleMapping('langs', 'js', 'Mozilla Services', 'Firefox Sync: Backend');
 addLanguageMapping('cpp', 'c++');


### PR DESCRIPTION
When searching for Java related bugs, the bugs displayed includes the one from Javascript. This is because bugs are filtered from bugzilla with whiteboard containing  string  lang=java. It should be [lang=java] as the former includes lang=javascript. 
This is a cheap hack to get the search to filter for java only. 
