### PR TITLE
Only decrement pending requests on non-cached requests

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -439,7 +439,6 @@ function rebuildTableContents() {
 
   document.getElementById('total').textContent = '(' + orderedBugList.length + ')';
 
-  pendingRequests--;
   if (pendingRequests === 0) {
     document.getElementById('throbber').style.visibility = "hidden";
   }
@@ -505,6 +504,7 @@ function retrieveResults(category) {
           resultsCache[category].push(unfinishedResults[category][i]);
       }
       delete unfinishedResults[category];
+      pendingRequests--;
       rebuildTableContents();
     }
   }


### PR DESCRIPTION
This fixes a bug where the throbber persists after unticking and reticking an already chosen category.
