### PR TITLE
Adding Interest Dashboard component.

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@ Bugs Ahoy! <div><i>these bugs are relevant to my interests</i></div>
                    ["devtools", "Firefox Developer Tools"], ["releng", "Release Engineering"], ["reporting", "Dashboards and Reporting"],
                    ["automation", "Test Automation"], ["sync", "Firefox Sync"], ["thunderbird", "Thunderbird"],
                    ["seamonkey", "SeaMonkey"], ["calendar", "Calendar"], ["b2g", "Boot2Gecko / Firefox OS"], ["metro", "Metro (Windows 8)"], ["webmaker","Webmaker"],
-                   ["appsengineering", "Apps Engineering"], ["servo", "Servo"], ["oneanddone", "One and Done"]]);
+                   ["appsengineering", "Apps Engineering"], ["servo", "Servo"], ["oneanddone", "One and Done"], ["contentservices","Firefox Interest Dashboard"]]);
   </script>
 <br><br>
 Do you know: <br><br>

--- a/magic.js
+++ b/magic.js
@@ -251,6 +251,7 @@ addComponentMapping('b2g', 'Firefox OS');
 addComponentMapping('b2g', 'Core', ['DOM: Device Interfaces', 'Hardware Abstraction Layer (HAL)']);
 addGithubComponentMapping('b2g', 'mozilla-b2g/gaia', 'mentored');
 addComponentMapping('metro', 'Firefox for Metro');
+addComponentMapping('contentservices', 'Content Services', ['Interest Dashboard']);
 addComponentMapping('webmaker', 'Webmaker', ['Badges',
                                              'Community',
                                              'DevOps',


### PR DESCRIPTION
I wasn't able to test this, got a 501 after running `python -m CGIHTTPServer` and going to `localhost:8000`.

I think there's probably something else needed here to only show Interest Dashboard bugs instead of all Content Services bugs?

Thanks!
