### PR TITLE
Added component data to bug info popup

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -423,7 +423,7 @@ function rebuildTableContents() {
     if (daysOld !== 1) {
         elem.setAttribute('alt', daysOld + " days since last update<br /> Assigned to : " + orderedBugList[idx].assigned_to.real_name + " <br /> Component : " + orderedBugList[idx].component);
     }else{
-        elem.setAttribute('alt', daysOld + " day since last update<br /> Assigned to : " + orderedBugList[idx].assigned_to.real_name);
+        elem.setAttribute('alt', daysOld + " day since last update<br /> Assigned to : " + orderedBugList[idx].assigned_to.real_name + " <br /> Component : " + orderedBugList[idx].component);
     }
 
 

--- a/magic.js
+++ b/magic.js
@@ -551,6 +551,7 @@ function retrieveResults(category) {
            data[d].assigned_to = data.assignee || {real_name: "nobody"};
            data[d].summary = user + '/' + name + ' - ' + data[d].title;
            data[d].last_change_time = data[d].updated_at;
+           data[d].component = name;
          }
          processResult(null, data);
       }).error(function() { processResult(null, []); });

--- a/magic.js
+++ b/magic.js
@@ -421,7 +421,7 @@ function rebuildTableContents() {
 
     elem.setAttribute('class', "bug moreInfo");
     if (daysOld !== 1) {
-        elem.setAttribute('alt', daysOld + " days since last update<br /> Assigned to : " + orderedBugList[idx].assigned_to.real_name);
+        elem.setAttribute('alt', daysOld + " days since last update<br /> Assigned to : " + orderedBugList[idx].assigned_to.real_name + " <br /> Component : " + orderedBugList[idx].component);
     }else{
         elem.setAttribute('alt', daysOld + " day since last update<br /> Assigned to : " + orderedBugList[idx].assigned_to.real_name);
     }
@@ -519,7 +519,7 @@ function retrieveResults(category) {
                         o1: 'isnotempty',
                         whiteboard_type: 'contains_all',
                         bug_status: ["NEW","ASSIGNED","REOPENED", "UNCONFIRMED"],
-                        include_fields: ["id","assigned_to","summary","last_change_time"],
+                        include_fields: ["id","assigned_to","summary","last_change_time","component"],
                         /*component_type: 'equals',*/
                         product: ''};
     for (var param in mapping[i]) {


### PR DESCRIPTION
Added component data to the popup that displays when the user hovers over bug as discussed in Issue #67.

This request differs from closed pull request #129, as it displays component data regardless of the number of days that have passed since the bug has been updated.