### PR TITLE
Link to BMO directly instead of a 3rd party redirector

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -394,7 +394,7 @@ function rebuildTableContents() {
     var inner = document.createElement('span');
     var link = document.createElement('a');
     elem.setAttribute('tabindex', '0');
-    var url = bug.html_url || "http://bugzil.la/" + bug.id;
+    var url = bug.html_url || "https://bugzilla.mozilla.org/" + bug.id;
     link.setAttribute('href', url);
     link.setAttribute('target', "_blank");
     var text = document.createTextNode(bug.id);


### PR DESCRIPTION
bugsahoy's current links to bugs uses bugzil.la.  this is a 3rd party url shortener owned and managed by a member of the mozilla community.

while bugzil.la is awesome i think it makes more sense to link to BMO directly.