### PR TITLE
Update Loop's product name to match its new name

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -188,8 +188,8 @@ addComponentMapping('ff', 'Firefox');
 addComponentMapping('ff', 'Toolkit');
 addComponentMapping('ff', 'Mozilla Services', 'Firefox Sync: UI');
 addComponentMapping('ff', 'Input', ['Frontend', 'General']);
-addComponentMapping('ff', 'Loop', ['Client']);
-addComponentMapping('loop', 'Loop');
+addComponentMapping('ff', 'Hello (Loop)', ['Client']);
+addComponentMapping('loop', 'Hello (Loop)');
 addComponentMapping('devtools', 'Firefox',
                     ['Developer Tools',
                      'Developer Tools: 3D View',


### PR DESCRIPTION
Bug 1171523 changed the bugzilla product name from "Loop" to "Hello (Loop)". We need to update bugsahoy for this as well.