### PR TITLE
Update the repo URL for Treeherder

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@ Display only: <br><br>
   addExtra('jseng', 'Extra information for the JS engine', 'Get involved with the <a href="https://wiki.mozilla.org/JavaScript:New_to_SpiderMonkey" target="_blank">JS engine</a> team');
   addExtra('a11y', 'Extra information for Accessibility', 'Get involved with the <a href="https://wiki.mozilla.org/Accessibility/Contribute" target="_blank">Accessibility</a> team');
   addExtra('releng', 'Extra information for Release Engineering', 'Get involved with the <a href="https://wiki.mozilla.org/ReleaseEngineering/Contribute" target="_blank">Release Engineering</a> team');
-  addExtra('reporting', 'Extra information for Dashboards', 'Find out more about the <a href="https://github.com/mozilla/treeherder-ui" target="_blank">Treeherder</a> dashboard and its components');
+  addExtra('reporting', 'Extra information for Dashboards', 'Find out more about the <a href="https://github.com/mozilla/treeherder" target="_blank">Treeherder</a> dashboard and its components');
   addExtra('sync', 'Extra information for Firefox Sync' , 'Get involved with the <a href="https://wiki.mozilla.org/Services/Sync#Get_Involved" target="_blank">Sync</a> team');
   addExtra('seamonkey', 'Extra information for SeaMonkey', 'Get involved with the <a href="http://www.seamonkey-project.org" target="_blank">SeaMonkey Project</a>');
   addExtra('js', 'Extra information for JS', 'Get involved with the <a href="https://github.com/mozilla/pdf.js" target="_blank">PDF.js project</a><br>Get involved with the <a href="https://github.com/kripken/emscripten/">emscripten project</a><br>Get involved with the <a href="https://wiki.mozilla.org/Webdev/GetInvolved">WebDev</a> team');


### PR DESCRIPTION
The treeherder-ui repo is deprecated, since it was merged into the main treeherder repository.