### PR TITLE
Add good-first-bug keyword search for simple bugs (Fixes #155)

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -370,6 +370,7 @@ addSearchMapping('ownership', 'unowned',
                  {assigned_to: ['nobody@mozilla.org', 'general@js.bugs']}
                 );
 addSearchMapping('simple', 'simple', {status_whiteboard: 'good first bug'});
+addSearchMapping('simple', 'simple', {keywords: 'good-first-bug'});
 addSearchMapping('diamond', 'diamond', {status_whiteboard: 'diamond'});
 
 var interestingComponents = [];


### PR DESCRIPTION
There are already some good first bugs that have `good-first-bugs` keyword but doesn't have `[good first bug]` whiteboard (search with keyword+whiteboard -> 471 bugs, search with whiteboard -> 451 bugs)
Also, not all bugs have `good-first-bugs` keyword yet (search with keyword -> 60 bugs)

So, it would be nice to add another mapping for keywords, for now, in addition to whiteboard.
We could remove the mapping for whiteboard once all bugs have been migrated to keywords.
