### PR TITLE
Use three column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,148 +17,150 @@
 <div id="ba-total-header" role="banner">
 Bugs Ahoy! <div><i>these bugs are relevant to my interests</i></div>
 </div>
-<div id="ba-content">
-  Are you interested in:<br><br>
-<div id="ba-choices" role="navigation">
-  <script>
-    function addCategories(cats) {
-      var choices = document.getElementById('ba-choices');
-      for (var i = 0; i < cats.length; i++) {
-        var elem = document.createElement('div');
-        var inp = document.createElement('input');
-        inp.type = "checkbox";
-        inp.onchange = toggleCategory;
-        inp.setAttribute('id', cats[i][0]);
-        var lab = document.createElement('label');
-        lab.setAttribute('for', cats[i][0]);
-        var text = document.createTextNode(cats[i][1]);
-        lab.appendChild(text);
-        elem.appendChild(inp);
-        elem.appendChild(lab);
-        choices.appendChild(elem);
-      }
-    }
 
-    function addGroupedCategories(cats) {
-      var choices = document.getElementById('ba-choices');
-      for (var i = 0; i < cats.length; i++) {
-        var elem = document.createElement('div');
-        elem.setAttribute('class', 'choice-group');
-        var title = document.createElement('div');
-        title.textContent = cats[i].name;
-        elem.appendChild(title);
-        for (var j = 0; j < cats[i].entries.length; j++) {
-          var div = document.createElement('div');
-          elem.appendChild(div);
+<div id="ba-content">
+  <div id="ba-choices" role="navigation">
+    <p class="choice-title">Are you interested in:</p>
+    <script>
+      function addCategories(cats) {
+        var choices = document.getElementById('ba-choices');
+        choices.setAttribute('class', 'choice-group');
+        for (var i = 0; i < cats.length; i++) {
+          var elem = document.createElement('div');
           var inp = document.createElement('input');
           inp.type = "checkbox";
           inp.onchange = toggleCategory;
-          var details = cats[i].entries[j];
-          inp.setAttribute('id', details[0]);
+          inp.setAttribute('id', cats[i][0]);
           var lab = document.createElement('label');
-          lab.setAttribute('for', details[0]);
-          var text = document.createTextNode(details[1]);
+          lab.setAttribute('for', cats[i][0]);
+          var text = document.createTextNode(cats[i][1]);
           lab.appendChild(text);
-          div.appendChild(inp);
-          div.appendChild(lab);
+          elem.appendChild(inp);
+          elem.appendChild(lab);
+          choices.appendChild(elem);
         }
-        choices.appendChild(elem);
       }
-    }
 
-    var categories = [
-      {
-        'name': 'Web Platform',
-        'entries': [["a11y", "Accessibility"],
-                    ["gfx", "Graphics"],
-                    ["net", "Networking"],
-                    ["jseng", "JavaScript Engine"],
-                    ["layout", "Layout"],
-                    ["dom", "DOM and CSS technology"],
-                    ["editor", "Input handling"],
-                    ["media", "Media"]]
-      },
-      {
-        'name': 'Firefox',
-        'entries': [["ff", "User interface"],
-                    ["devtools", "Developer Tools"],
-                    ["internals", "Internals"],
-                    ["internals-android", "Internals (Android)"],
-                    ["internals-gtk", "Internals (GTK)"],
-                    ["internals-osx", "Internals (OSX)"],
-                    ["internals-win32", "Internals (Windows)"],
-                    ["mobileandroid", "Mobile (Android)"],
-                    ["mobileios", "Mobile (iOS)"],
-                    ["sync", "Sync"],
-                    ["webextensions", "Web Extensions"]]
-      },
-      {
-        'name': 'Other',
-        'entries': [["b2g", "Boot2Gecko / Firefox OS"],
-                    ["thunderbird", "Thunderbird"],
-                    ["instantbird", "Instantbird"],
-                    ["seamonkey", "SeaMonkey"],
-                    ["calendar", "Calendar"],
-                    ["servo", "Servo"],
-                    ["mdn", "MDN / Developer Documentation"]]
-      },
-      {
-        'name': 'Support',
-        'entries': [["build", "Build System"],
-                    ["releng", "Release Engineering"],
-                    ["taskcluster", "TaskCluster"],
-                    ["reporting", "Dashboards and Reporting"],
-                    ["automation", "Test Automation"],
-                    ["appsengineering", "Apps Engineering"]]
-      },
-      {
-        'name': 'Web Development',
-        'entries': [["bugzilla", "Bugzilla"],
-                    ["contentservices","Firefox Interest Dashboard"],
-                    ["addons", "addons.mozilla.org"],
-                    ["marketplace", "Firefox Marketplace"],
-                    ["webmaker","Webmaker"]]
-      },
-    ];
+      function addGroupedCategories(cats) {
+        var choices = document.getElementById('ba-choices');
+        for (var i = 0; i < cats.length; i++) {
+          var elem = document.createElement('div');
+          elem.setAttribute('class', 'choice-group');
+          var title = document.createElement('div');
+          title.textContent = cats[i].name;
+          title.setAttribute('class', 'choice-group-title');
+          elem.appendChild(title);
+          for (var j = 0; j < cats[i].entries.length; j++) {
+            var div = document.createElement('div');
+            elem.appendChild(div);
+            var inp = document.createElement('input');
+            inp.type = "checkbox";
+            inp.onchange = toggleCategory;
+            var details = cats[i].entries[j];
+            inp.setAttribute('id', details[0]);
+            var lab = document.createElement('label');
+            lab.setAttribute('for', details[0]);
+            var text = document.createTextNode(details[1]);
+            lab.appendChild(text);
+            div.appendChild(inp);
+            div.appendChild(lab);
+          }
+          choices.appendChild(elem);
+        }
+      }
 
-    addGroupedCategories(categories);
+      var categories = [
+        {
+          'name': 'Web Platform',
+          'entries': [["a11y", "Accessibility"],
+                      ["gfx", "Graphics"],
+                      ["net", "Networking"],
+                      ["jseng", "JavaScript Engine"],
+                      ["layout", "Layout"],
+                      ["dom", "DOM and CSS technology"],
+                      ["editor", "Input handling"],
+                      ["media", "Media"]]
+        },
+        {
+          'name': 'Firefox',
+          'entries': [["ff", "User interface"],
+                      ["devtools", "Developer Tools"],
+                      ["internals", "Internals"],
+                      ["internals-android", "Internals (Android)"],
+                      ["internals-gtk", "Internals (GTK)"],
+                      ["internals-osx", "Internals (OSX)"],
+                      ["internals-win32", "Internals (Windows)"],
+                      ["mobileandroid", "Mobile (Android)"],
+                      ["mobileios", "Mobile (iOS)"],
+                      ["sync", "Sync"],
+                      ["webextensions", "Web Extensions"]]
+        },
+        {
+          'name': 'Other',
+          'entries': [["b2g", "Boot2Gecko / Firefox OS"],
+                      ["thunderbird", "Thunderbird"],
+                      ["instantbird", "Instantbird"],
+                      ["seamonkey", "SeaMonkey"],
+                      ["calendar", "Calendar"],
+                      ["servo", "Servo"],
+                      ["mdn", "MDN / Developer Documentation"]]
+        },
+        {
+          'name': 'Support',
+          'entries': [["build", "Build System"],
+                      ["releng", "Release Engineering"],
+                      ["taskcluster", "TaskCluster"],
+                      ["reporting", "Dashboards and Reporting"],
+                      ["automation", "Test Automation"],
+                      ["appsengineering", "Apps Engineering"]]
+        },
+        {
+          'name': 'Web Development',
+          'entries': [["bugzilla", "Bugzilla"],
+                      ["contentservices","Firefox Interest Dashboard"],
+                      ["addons", "addons.mozilla.org"],
+                      ["marketplace", "Firefox Marketplace"],
+                      ["webmaker","Webmaker"]]
+        },
+      ];
 
-  </script>
-Do you know: <br><br>
-<script>
-    addCategories([["py", "Python"], ["java", "Java"], ["sh", "Shell/Makefile/Autoconf"],
-                   ["js", "JavaScript"], ["cpp", "C/C++"], ["html", "HTML/CSS"], ["xml", "XML/XUL"],
-                   ["perl", "Perl"]]);
-</script>
-<br><br>
-Display only: <br><br>
-<script>
-    addCategories([["unowned", "Unassigned bugs"],
-                   ["simple", "Simple bugs"],
-		   ["diamond", "Diamond Bugs"]]);
-</script>
-</div>
+      addGroupedCategories(categories);
 
-<div id="bugs" role="main">
-  <div id="ba-header" role="log">Results <span id="total"></span> <img id="throbber" alt="Fetching results" src="loading.gif" style="visibility: hidden; float: right"></div>
-  <div id="simple-hint">Do you want to display only simple bugs?
-    <input type="button" value="No" onclick="$(this.parentNode).fadeOut()">
-    <input type="button" value="Yes" onclick="document.getElementById('simple').checked = true; toggleCategoryById('simple');">
+    </script>
+    <p class="choice-title">Do you know:</p>
+    <script>
+        addCategories([["py", "Python"], ["java", "Java"], ["sh", "Shell/Makefile/Autoconf"],
+                       ["js", "JavaScript"], ["cpp", "C/C++"], ["html", "HTML/CSS"], ["xml", "XML/XUL"],
+                       ["perl", "Perl"]]);
+    </script>
+    <p class="choice-title">Display only:</p>
+    <script>
+        addCategories([["unowned", "Unassigned bugs"],
+                       ["simple", "Simple bugs"],
+                       ["diamond", "Diamond Bugs"]]);
+    </script>
   </div>
-  <div id="bugs_content">
-    <div class="bug"><span>No categories specified.</span></div>
+
+  <div id="bugs" role="main">
+    <div id="ba-header" role="log">Results <span id="total"></span> <img id="throbber" alt="Fetching results" src="loading.gif" style="visibility: hidden; float: right"></div>
+    <div id="simple-hint">Do you want to display only simple bugs?
+      <input type="button" value="No" onclick="$(this.parentNode).fadeOut()">
+      <input type="button" value="Yes" onclick="document.getElementById('simple').checked = true; toggleCategoryById('simple');">
+    </div>
+    <div id="bugs_content">
+      <div class="bug"><span>No categories specified.</span></div>
+    </div>
   </div>
-</div>
 
-</div>
+  <aside class="aside">
+    <ul id="ba-extra" role="complementary"></ul>
 
-<ul id="ba-extra" role="complementary">
-</ul>
-
- <div class="ba-twitter">
-  <a class="twitter-timeline" swidth="500"
-  height="300" href="https://twitter.com/StartMozilla" data-widget-id="514951453161422848">Tweets by @StartMozilla</a>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+    <div class="ba-twitter">
+      <a class="twitter-timeline" swidth="500"
+      height="300" href="https://twitter.com/StartMozilla" data-widget-id="514951453161422848">Tweets by @StartMozilla</a>
+      <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+    </div>
+  </aside>
 </div>
 
 <script>
@@ -224,8 +226,5 @@ Display only: <br><br>
     <i><a href="https://wiki.mozilla.org/BugsAhoy">Bugs Ahoy!</a></i> <span>is written by <a href="https://mozillians.org/en-US/u/jdm/">Josh Matthews</a>
 (get the <a href="http://github.com/jdm/bugsahoy/">source</a>!)</span>
 </div>
-<!--OHHDEAR-->
-<center><div id="help"></div>
-</center>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -5,28 +5,33 @@ body {
 }
 
 #ba-content {
-    width: 100%;
-/*  width: 70%;
-  left: 500px;
-top: 100px;*/
-  /*margin-left: -35%;*/
-  /*border: red solid 1px;*/
+  margin: 0 auto;
+  max-width: 1170px;
 }
 
 #ba-choices {
     float: left;
-    /*border: green 1px solid;*/
+    width: 18%;
 }
 
 #ba-choices div {
     width: 100%;
 }
 
-.choice-group {
-    padding-bottom: 1.5em;
+.choice-title {
+    margin-bottom: 1em;
+    margin-top: 2em;
 }
 
-.choice-group div:first-of-type {
+.choice-title:first-child {
+  margin-top: 0;
+}
+
+.choice-group {
+    margin-bottom: 1.5em;
+}
+
+.choice-group-title {
     font-weight: bold;
 }
 
@@ -36,11 +41,11 @@ top: 100px;*/
 
 #bugs {
   float: left;
-  width: 550px;
   font-size: 1.02em;
-  margin-left: 5.2em;  
+  margin-left: 3.5%;
   box-shadow: rgba(0,0,0,.2) 0 .15em 0.6em;
   border-radius: 4px 4px 0 0;
+  width: 50%;
 }
 
 #ba-header {
@@ -61,42 +66,32 @@ div .bug {
       padding-left: 14px;
 }
 
-/*#help {
-    background: #F9F9F9;
-    border: 1px black dashed;
-    width: 40%;
-    float: right;
-    padding: 8px;
-    display: none;   
-}*/
-
 a.diamond-bug {
   background-color: yellow;
 }
 
+.aside {
+  float: right;
+  margin-left: 3.5%;
+  width: 25%;
+}
+
 #ba-extra {
     list-style-type: none;
-    margin-top: 0;
+    margin: 0;
+    padding: 0;
 }
 
 #ba-extra li {
-  float:left;
   font-size: 1.02em;
-  margin-left: 5.2em;  
   box-shadow: rgba(0,0,0,.2) 0 .15em 0.6em;
   border-radius: 4px 4px 0 0;
   text-align: center;
-  width: 25%;
   display: none;
   margin-bottom: 2em;
   background: none;
   padding-left: 0px;
-}
-
-.ba-twitter {
-      float: left;
-      width: 25%;
-      margin-left: 5.2em;
+  width: 100%;
 }
 
 .ba-extra_header {


### PR DESCRIPTION
This PR modifies the markup and CSS in order to:
* Use a real three column layout. Fixes some bugs and it makes it easier to make the page responsive in the future. Actually, it already looks good at >800px.
* Align the three columns on top (before, _Are you interested in:_ was misaligned).
* Center the content of the page (on wide screens it was aligned to the left).
* Group left options in a more coherent way. Now all styling is done using three classes `.choice-title`, `.choice-group` and `.choice-group-title`.
* Fix some indentation issues (sorry, this messes up the diff).
* Remove `#help` div at the bottom of the page. I grep'ed it and couldn't find any call to it.

Fixes:
#137