### PR TITLE
Add internship link

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,10 @@ Bugs Ahoy! <div><i>these bugs are relevant to my interests</i></div>
       height="300" href="https://twitter.com/StartMozilla" data-widget-id="514951453161422848">Tweets by @StartMozilla</a>
       <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
     </div>
+
+    <div class="ba-internships">
+        <span>Are you interested in an <a href="https://wiki.mozilla.org/Internship_Opportunities">internship</a> at Mozilla?</span>
+    </div>
   </aside>
 </div>
 


### PR DESCRIPTION
This adds an "aside" link to the new "Internship Opportunities" page on
the Mozilla Wiki, which in turn links to Bugs Ahoy.
