### PR TITLE
Refactor simple-hint bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,9 +143,12 @@ Bugs Ahoy! <div><i>these bugs are relevant to my interests</i></div>
 
   <div id="bugs" role="main">
     <div id="ba-header" role="log">Results <span id="total"></span> <img id="throbber" alt="Fetching results" src="loading.gif" style="visibility: hidden; float: right"></div>
-    <div id="simple-hint">Do you want to display only simple bugs?
-      <input type="button" value="No" onclick="$(this.parentNode).fadeOut()">
-      <input type="button" value="Yes" onclick="document.getElementById('simple').checked = true; toggleCategoryById('simple');">
+    <div id="simple-hint" class="simple-hint">
+      <div class="simple-hint-text">Do you want to display only simple bugs?</div>
+      <div class="simple-hint-buttons">
+        <input class="simple-hint-button" type="button" value="Yes" onclick="document.getElementById('simple').checked = true; toggleCategoryById('simple');">
+        <input class="simple-hint-button" type="button" value="No" onclick="$(this.parentNode).fadeOut()">
+      </div>
     </div>
     <div id="bugs_content">
       <div class="bug"><span>No categories specified.</span></div>

--- a/style.css
+++ b/style.css
@@ -144,15 +144,25 @@ a.diamond-bug {
     font-weight: normal;
 }
 
-#simple-hint {
+.simple-hint {
     background-color: #F7F7C0;
     overflow: hidden;
-    font-size: 1.1em;
     border: 1px solid #ccc;
     padding: 9px 14px;
     display: none;
 }
 
-#simple-hint input {
+.simple-hint-text {
+    float: left;
+    font-size: 1.1em;
+    line-height: 1.9em;
+}
+
+.simple-hint-buttons {
     float: right;
+    white-space: nowrap;
+}
+
+.simple-hint-button {
+    height: 1.9em:
 }


### PR DESCRIPTION
This small PR fixes some issues:
- The text and the buttons of the #simple-hint bar were not aligned.
![image](https://cloud.githubusercontent.com/assets/3616980/23810545/5270f590-05d2-11e7-9ca1-753f0e3af78d.png)
- When the window was small, the buttons were breaking in different lines.
![image](https://cloud.githubusercontent.com/assets/3616980/23810570/62bc5084-05d2-11e7-8b86-c17db6185458.png)
- In the code, 'No' button was before 'Yes' but visually it was the other way around. Now 'Yes' is always the first button, so people with screen readers get the buttons in the same order than users using a screen. It also makes keyboard navigation more logical.