### PR TITLE
Add mozilla/telemetry-dashboard github component mapping

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -168,6 +168,7 @@ addComponentMapping('internals', 'Core', ['General', 'Widget', 'Document Navigat
 addComponentMapping('internals', 'NSPR');
 addComponentMapping('internals', 'NSS');
 addComponentMapping('internals', 'Toolkit', ['Telemetry', 'Add-ons Manager']);
+addGithubComponentMapping('internals', ['mozilla/telemetry-dashboard'], 'mentored');
 addComponentMapping('internals-android', 'Core', ['Widget: Android']);
 addComponentMapping('internals-gtk', 'Core', ['Embedding: GTK Widget', 'Widget: Gtk']);
 addComponentMapping('internals-osx', 'Core', ['Embedding: Mac', 'Widget: Cocoa']);


### PR DESCRIPTION
There are some good first bugs in mozilla/telemetry-dashboard that we would like to surface in Bugs Ahoy