### PR TITLE
Update labels for mozilla-releng/services

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -256,8 +256,8 @@ addGithubComponentMapping('automation', ['marco-c/code-coverage-reports'],
                            'js': 'javascript',
                            'py': 'python' });
 addGithubComponentMapping('automation', ['mozilla-releng/services'],
-                          '3.skill: good-first-bug',
-                          {'py': '5.lang: python' });
+                          'skill:good-first-bug',
+                          {'py': 'lang:python' });
 
 addComponentMapping('sync', 'Cloud Services', ['Firefox Sync: Backend',
                                                'Firefox Sync: Build',


### PR DESCRIPTION
We have simplified the labels for the project (https://github.com/mozilla-releng/services/issues/755).