### PR TITLE
Remove remaining UI for B2G (#180)

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,8 +97,7 @@ Bugs Ahoy! <div><i>these bugs are relevant to my interests</i></div>
         },
         {
           'name': 'Other',
-          'entries': [["b2g", "Boot2Gecko / Firefox OS"],
-                      ["thunderbird", "Thunderbird"],
+          'entries': [["thunderbird", "Thunderbird"],
                       ["instantbird", "Instantbird"],
                       ["seamonkey", "SeaMonkey"],
                       ["calendar", "Calendar"],


### PR DESCRIPTION
This just removes the remaining UI reference to FxOS / B2G. The functionality was removed in b1107e6.